### PR TITLE
added print count in rounds + behaviour

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,8 +1,8 @@
 {
     "dev": {
-        "skill/valory/hello_world_abci/0.1.0": "bafybeiefpbns33dx3m2dsiarinqk5azgpcowmpjj5kexs6e7ws4yhsw4d4",
-        "agent/valory/hello_world/0.1.0": "bafybeifhcwhwc5hnffxyb5csflg3izv2uub47a5h74ugth47gmgg56mqsu",
-        "service/valory/hello_world/0.1.0": "bafybeiddqpovnzn4ud7cj45bcwbm5apktgdzwvbzxkglca355oeubxgizi"
+        "skill/valory/hello_world_abci/0.1.0": "bafybeibleayi6phwqieiwoa7iuu7ljazbxdgx2e4u22kb2kr7vr4637gzi",
+        "agent/valory/hello_world/0.1.0": "bafybeibgzbqprldlhyweh43nbvy6ea7o6mnsh2f4jdiob5cg4llln7n5ji",
+        "service/valory/hello_world/0.1.0": "bafybeialpicdc42jhsmqmgdzpqh4blyjlgf2fgpwevqza53umholdwxgei"
     },
     "third_party": {
         "protocol/valory/acn/1.1.0": "bafybeidluaoeakae3exseupaea4i3yvvk5vivyt227xshjlffywwxzcxqe",

--- a/packages/valory/agents/hello_world/aea-config.yaml
+++ b/packages/valory/agents/hello_world/aea-config.yaml
@@ -25,7 +25,7 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeicr24cgdovqdp4bh25bpun77v7u33maydwuxwled3tuhyiaepw5gu
 - valory/abstract_round_abci:0.1.0:bafybeia6lemk5s64f26qjnd2746s5mufpzxuaf5frsqhfbr62kk3ma6sp4
-- valory/hello_world_abci:0.1.0:bafybeiefpbns33dx3m2dsiarinqk5azgpcowmpjj5kexs6e7ws4yhsw4d4
+- valory/hello_world_abci:0.1.0:bafybeibleayi6phwqieiwoa7iuu7ljazbxdgx2e4u22kb2kr7vr4637gzi
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/services/hello_world/service.yaml
+++ b/packages/valory/services/hello_world/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiapubcoersqnsnh3acia5hd7otzt7kjxekr6gkbrlumv6tkajl6jm
 fingerprint_ignore_patterns: []
-agent: valory/hello_world:0.1.0:bafybeifhcwhwc5hnffxyb5csflg3izv2uub47a5h74ugth47gmgg56mqsu
+agent: valory/hello_world:0.1.0:bafybeibgzbqprldlhyweh43nbvy6ea7o6mnsh2f4jdiob5cg4llln7n5ji
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/hello_world_abci/payloads.py
+++ b/packages/valory/skills/hello_world_abci/payloads.py
@@ -56,3 +56,9 @@ class ResetPayload(BaseTxPayload):
     """Represent a transaction payload of type 'reset'."""
 
     period_count: int
+
+ 
+@dataclass(frozen=True)
+class PrintCountPayload(BaseTxPayload):
+    """Represent a transaction payload for tracking print count."""
+    print_count: int

--- a/packages/valory/skills/hello_world_abci/skill.yaml
+++ b/packages/valory/skills/hello_world_abci/skill.yaml
@@ -8,13 +8,13 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   README.md: bafybeidrjtykhovnccj3sovugdn4r3tszuzv7h37vta6o35epi5qfzdpke
   __init__.py: bafybeibiblks3d3s3ditug4hfzl3ob3cibokcz4ofs7cbbsbqw5zzbtd3m
-  behaviours.py: bafybeid2mo7jbjzsfazao5by4mrjka3ru2rwo64dogjiqszmmqxvezg654
+  behaviours.py: bafybeicuqemxueotjlokpws43ael63gwlrzpl43e6ehweo3z2awytodu5i
   dialogues.py: bafybeigabhaykiyzbluu4mk6bbrmqhzld2kyp32pg24bvjmzrrb74einwm
   fsm_specification.yaml: bafybeibsjhlpuigtbmtcusv4qrtebal23ylv2sulj6dolvln6fwlkjp23a
   handlers.py: bafybeieyq37quymqq6md3hi5bvynifnkx73bcvmzct6difyvdkbzj6abaq
-  models.py: bafybeiaawt2dtusfk3uabo4etvfqc4p3n7amaxqpthhx4dx4opo2ru4fd4
-  payloads.py: bafybeiajaxhepvqsznhgadw24w4zumfpxcqysv7y4mdsnh5awvtvirpb3q
-  rounds.py: bafybeidxkjo6us24fj46fwfxopbbd3njystt4nuqmgpvrmigestr36tkou
+  models.py: bafybeidym2ekwwlki2uyedtiw7ljzsobcwagcfimkhof7jlquwgtklftni
+  payloads.py: bafybeigd3cylykxh24qcbtdn7uy4n3fo7ykkakno5xek26scfamjtppava
+  rounds.py: bafybeigllqbaajxrf4lz4ife6cn4t725mcuh5tbiijdqdpackxncfincyy
   tests/__init__.py: bafybeibpuwe63mjjwnaanx7wdw63reh6qa5xdtjxdf75o3nksvjercte4y
   tests/test_behaviours.py: bafybeie6b5ibatxs4dlunkzj3b6k7al4ifgqyynh2qvbjekkbbnhlum4iy
   tests/test_dialogues.py: bafybeiarl4wsnljaxkgxdwr47xd4xjjjtkfgqbtazt2v2oem47alhaykj4


### PR DESCRIPTION
# Add Print Count Tracking Feature

## Overview
This PR adds functionality to track and display how many times the `PrintMessageRound` has been executed in the Hello World service. It implements a new state in the FSM that follows the `PrintMessageRound` and maintains a counter in the `SynchronizedData`.

## Key Changes
- Added new `print_count` variable to `SynchronizedData`
- Created `PrintCountPayload` class to handle the counter updates
- Implemented `PrintCountRound` that inherits from `CollectSameUntilThresholdRound`
- Added `PrintCountBehaviour` to manage the counting logic and display
- Configured cross-period persistence for the counter

## Implementation Details
- The `PrintCountBehaviour` retrieves and increments the current count, displays it, and sends the updated value
- The `PrintCountRound` collects votes and updates the synchronized data when threshold is reached
- Counter persistence is maintained across periods using `cross_period_persisted_keys`
- Added proper logging for tracking count updates

## Testing
- [x] Add tests for `PrintCountRound`
- [ ] Add tests for `PrintCountBehaviour`
- [x] Verify counter persistence across periods
- [x] Test consensus mechanism for count updates

## Related Issues
- Implements tracking feature for PrintMessageRound execution count
- Enhances service observability